### PR TITLE
refresh icons on create dir and kill subdir

### DIFF
--- a/nerd-icons-dired.el
+++ b/nerd-icons-dired.el
@@ -112,6 +112,8 @@
     (advice-add 'dired-revert :around #'nerd-icons-dired--refresh-advice)
     (advice-add 'dired-internal-do-deletions :around #'nerd-icons-dired--refresh-advice)
     (advice-add 'dired-insert-subdir :around #'nerd-icons-dired--refresh-advice)
+    (advice-add 'dired-create-directory :around #'nerd-icons-dired--refresh-advice)
+    (advice-add 'dired-kill-subdir :around #'nerd-icons-dired--refresh-advice)
     (advice-add 'dired-do-kill-lines :around #'nerd-icons-dired--refresh-advice)
     (with-eval-after-load 'dired-narrow
       (advice-add 'dired-narrow--internal :around #'nerd-icons-dired--refresh-advice))
@@ -125,6 +127,8 @@
   (advice-remove 'dired-narrow--internal #'nerd-icons-dired--refresh-advice)
   (advice-remove 'dired-insert-subdir #'nerd-icons-dired--refresh-advice)
   (advice-remove 'dired-do-kill-lines #'nerd-icons-dired--refresh-advice)
+  (advice-remove 'dired-create-directory #'nerd-icons-dired--refresh-advice)
+  (advice-remove 'dired-kill-subdir #'nerd-icons-dired--refresh-advice)
   (nerd-icons-dired--remove-all-overlays))
 
 ;;;###autoload


### PR DESCRIPTION
this pr fixes the following:

adding new directory doesn't make the icon appear for it:
![image](https://github.com/rainstormstudio/nerd-icons-dired/assets/11769964/782b1227-9936-4a28-bc7b-a12ac2740965)


`dired-kill-subdir` leaves artifact icons from the killed subdir:
![image](https://github.com/rainstormstudio/nerd-icons-dired/assets/11769964/ad611bfd-9249-4416-9e1a-78648331904e)
