### PR TITLE
Support icons showing after inserting subtree with dired-sidebar.el

### DIFF
--- a/nerd-icons-dired.el
+++ b/nerd-icons-dired.el
@@ -118,6 +118,8 @@
     (advice-add 'dired-do-kill-lines :around #'nerd-icons-dired--refresh-advice)
     (with-eval-after-load 'dired-narrow
       (advice-add 'dired-narrow--internal :around #'nerd-icons-dired--refresh-advice))
+    (with-eval-after-load 'dired-subtree
+      (advice-add 'dired-subtree-toggle :around #'nerd-icons-dired--refresh-advice))
     (nerd-icons-dired--refresh)))
 
 (defun nerd-icons-dired--teardown ()
@@ -126,6 +128,7 @@
   (advice-remove 'dired-revert #'nerd-icons-dired--refresh-advice)
   (advice-remove 'dired-internal-do-deletions #'nerd-icons-dired--refresh-advice)
   (advice-remove 'dired-narrow--internal #'nerd-icons-dired--refresh-advice)
+  (advice-remove 'dired-subtree-toggle #'nerd-icons-dired--refresh-advice)
   (advice-remove 'dired-insert-subdir #'nerd-icons-dired--refresh-advice)
   (advice-remove 'dired-do-kill-lines #'nerd-icons-dired--refresh-advice)
   (advice-remove 'dired-create-directory #'nerd-icons-dired--refresh-advice)


### PR DESCRIPTION
Add support for inserting a subtree and showing icons when the user has [dired-sidebar.el](https://github.com/jojojames/dired-sidebar)

Before, inserted subtrees are missing icons.

After, it looks like you'd expect 👌 

<img width="100" alt="Screenshot 2023-12-09 at 19 14 38" src="https://github.com/rainstormstudio/nerd-icons-dired/assets/118202/beef2e6b-dd36-442f-928a-ff3a70071bf8">
