### PR TITLE
Ignore error for dired-get-filename

### DIFF
--- a/nerd-icons-dired.el
+++ b/nerd-icons-dired.el
@@ -84,7 +84,7 @@
     (goto-char (point-min))
     (while (not (eobp))
       (when (dired-move-to-filename nil)
-        (let ((file (dired-get-filename 'relative 'noerror)))
+        (let ((file (ignore-errors (dired-get-filename 'relative 'noerror))))
           (when file
             (let ((icon (if (file-directory-p file)
                             (nerd-icons-icon-for-dir file


### PR DESCRIPTION
Thank you for creating this package, it has been very helpful to me. However, I've encountered an error in Emacs when using both `nerd-icons-dired` and `dired-sidebar` simultaneously: "No subdir-alist in directory<2>".

Minimal reproducible configuration:

```lisp
(require 'package)

(setq package-enable-at-startup nil)
(setq package-archives '(("gnu"   . "https://mirrors.tuna.tsinghua.edu.cn/elpa/gnu/")
                         ("melpa" . "https://mirrors.tuna.tsinghua.edu.cn/elpa/melpa/")))

(let ((package-selected-packages '(use-package)))
  (when (cl-find-if-not #'package-installed-p package-selected-packages)
    (package-refresh-contents)
    (mapc #'package-install package-selected-packages)))

(eval-when-compile
  (require 'use-package)
  (setq use-package-always-ensure t)
  (setq use-package-compute-statistics 1))

(use-package modus-themes
  :config
  (load-theme 'modus-operandi :no-confirm))

(use-package nerd-icons)

(use-package dired-sidebar
  :bind (("C-x C-n" . dired-sidebar-toggle-sidebar))
  :commands (dired-sidebar-toggle-sidebar)
  :config
  (setq dired-sidebar-theme 'nerd))

(use-package nerd-icons-dired
  :after (dired nerd-icons)
  :hook (dired-mode . nerd-icons-dired-mode))
```

Reproduction steps:

1. `M-x` toggle-debug-on-error
2. `C-x d` (Enter any directory containing folders)
3. `C-n` (Place cursor over any folder)
4. `C-x C-n` (Open dired-sidebar)"

Error log:

```
Debugger entered--Lisp error: (error "No subdir-alist in data<2>")
  signal(error ("No subdir-alist in data<2>"))
  error("No subdir-alist in %s" #<buffer data<2>>)
  dired-current-directory()
  dired-get-filename(relative noerror)
  nerd-icons-dired--refresh()
  nerd-icons-dired--setup()
  nerd-icons-dired-mode()
  run-hooks(change-major-mode-after-body-hook dired-mode-hook)
  apply(run-hooks (change-major-mode-after-body-hook dired-mode-hook))
  run-mode-hooks(dired-mode-hook)
  dired-mode()
  clone-buffer()
  dired-sidebar-get-or-create-buffer("/Users/lakor/data/")
  dired-sidebar-toggle-sidebar()
  funcall-interactively(dired-sidebar-toggle-sidebar)
  call-interactively(dired-sidebar-toggle-sidebar nil nil)
  command-execute(dired-sidebar-toggle-sidebar)
```

🤔I'm not familiar with Lisp, but it seems like `'noerror` in `(dired-get-filename 'relative 'noerror)` isn't behaving as expected? When I tried ignoring errors directly as done in this PR, everything worked fine, please review.
