### PR TITLE
add refresh advice on wdired abort

### DIFF
--- a/nerd-icons-dired.el
+++ b/nerd-icons-dired.el
@@ -120,6 +120,8 @@
       (advice-add 'dired-narrow--internal :around #'nerd-icons-dired--refresh-advice))
     (with-eval-after-load 'dired-subtree
       (advice-add 'dired-subtree-toggle :around #'nerd-icons-dired--refresh-advice))
+    (with-eval-after-load 'wdired
+      (advice-add 'wdired-abort-changes :around #'nerd-icons-dired--refresh-advice))
     (nerd-icons-dired--refresh)))
 
 (defun nerd-icons-dired--teardown ()
@@ -134,6 +136,7 @@
   (advice-remove 'dired-create-directory #'nerd-icons-dired--refresh-advice)
   (advice-remove 'dired-do-redisplay #'nerd-icons-dired--refresh-advice)
   (advice-remove 'dired-kill-subdir #'nerd-icons-dired--refresh-advice)
+  (advice-remove 'wdired-abort-changes #'nerd-icons-dired--refresh-advice)
   (nerd-icons-dired--remove-all-overlays))
 
 ;;;###autoload


### PR DESCRIPTION
fixes the following:
`wdired-change-to-wdired-mode`
then `wdired-abort-changes` (C-c ESC)

before:

![image](https://github.com/rainstormstudio/nerd-icons-dired/assets/11769964/e81a3281-5e4b-4266-8af1-23e93b313d46)

after:
![image](https://github.com/rainstormstudio/nerd-icons-dired/assets/11769964/935b8e34-5e90-4e5d-b6d5-4ceb27407bcc)
